### PR TITLE
Chisom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# C-Vault: Decentralized Time-Locked Asset Management
+
+C-Vault is a secure, decentralized smart contract for time-locked STX token management on the Stacks blockchain. It enables users to lock their assets for a specified period while providing emergency access options through beneficiary designation.
+
+## Overview
+
+C-Vault allows users to:
+- Create time-locked vaults for their STX tokens
+- Specify unlock times based on block heights
+- Designate beneficiaries for emergency access
+- Securely manage and access their funds once time-locks expire
+
+## Features
+
+### Secure Vault Creation
+Lock your STX tokens for a predetermined period, making them inaccessible until the specified block height is reached.
+
+### Flexible Deposits
+Add funds to your existing vault at any time. When adding funds, the unlock time will be set to the maximum of the current unlock time and the new specified unlock time.
+
+### Beneficiary Designation
+Designate a trusted individual as a beneficiary who can access your funds after the unlock time, providing an emergency backup access mechanism.
+
+### Full Control
+Once the unlock height is reached, withdraw partial or full amounts from your vault at your convenience.
+
+## Technical Details
+
+### Contract Functions
+
+#### Read-Only Functions
+
+- `get-vault`: Retrieves vault details for a specific owner
+- `vault-exists`: Checks if a vault exists for a given principal
+- `is-vault-unlocked`: Determines if a vault's time-lock has expired
+- `get-contract-balance`: Returns the contract's STX balance (for testing)
+
+#### Public Functions
+
+- `deposit`: Create a new vault or add to an existing one with a specified unlock height
+- `withdraw`: Withdraw funds from an unlocked vault
+- `set-beneficiary`: Designate a beneficiary for emergency access
+- `beneficiary-withdraw`: Allow a designated beneficiary to withdraw funds from an unlocked vault
+
+### Error Codes
+
+- `ERR_UNAUTHORIZED` (100): Caller is not authorized for the operation
+- `ERR_NO_VAULT` (101): Specified vault does not exist
+- `ERR_VAULT_LOCKED` (102): Vault is still time-locked
+- `ERR_INVALID_UNLOCK_TIME` (103): Specified unlock time is invalid
+- `ERR_ZERO_DEPOSIT` (104): Attempted to deposit zero tokens
+- `ERR_INSUFFICIENT_FUNDS` (105): Insufficient funds for withdrawal
+- `ERR_BENEFICIARY_ALREADY_SET` (106): Beneficiary is already set and cannot be changed
+- `ERR_INVALID_BENEFICIARY` (107): Invalid beneficiary specified (e.g., self-designation)
+
+## Usage Examples
+
+### Creating a Vault
+
+```clarity
+;; Lock 1000 STX for 1000 blocks
+(contract-call? .c-vault deposit u1000 (+ block-height u1000))
+```
+
+### Setting a Beneficiary
+
+```clarity
+;; Set a trusted individual as beneficiary
+(contract-call? .c-vault set-beneficiary 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM)
+```
+
+### Withdrawing Funds
+
+```clarity
+;; Withdraw 500 STX after unlock height is reached
+(contract-call? .c-vault withdraw u500)
+```
+
+### Beneficiary Withdrawal
+
+```clarity
+;; Beneficiary can withdraw funds after unlock height
+(contract-call? .c-vault beneficiary-withdraw 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM)
+```
+
+## Security Considerations
+
+- **Time-locks**: Funds cannot be withdrawn before the specified unlock height
+- **Beneficiary validation**: Beneficiaries cannot be the vault owner and cannot be changed once set
+- **Input validation**: All user inputs are carefully validated to prevent exploits
+- **Secure transfers**: Uses secure STX transfer mechanisms for all token movements
+
+## Development
+
+### Prerequisites
+
+- [Clarinet](https://github.com/hirosystems/clarinet) for local development and testing
+- Basic understanding of Clarity smart contracts and the Stacks blockchain
+
+### Testing
+
+Run comprehensive tests using Clarinet:
+
+```bash
+clarinet test
+```
+
+### Deployment
+
+Deploy to testnet or mainnet using Clarinet:
+
+```bash
+clarinet publish --testnet
+# or
+clarinet publish --mainnet
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request

--- a/contracts/time-locked.clar
+++ b/contracts/time-locked.clar
@@ -10,6 +10,7 @@
 (define-constant ERR_ZERO_DEPOSIT (err u104))
 (define-constant ERR_INSUFFICIENT_FUNDS (err u105))
 (define-constant ERR_BENEFICIARY_ALREADY_SET (err u106))
+(define-constant ERR_INVALID_BENEFICIARY (err u107))
 
 ;; Data structures
 (define-map vaults
@@ -158,6 +159,18 @@
   )
     ;; Check if vault exists
     (asserts! (vault-exists sender) ERR_NO_VAULT)
+    
+    ;; Validate beneficiary address
+    ;; Ensure beneficiary is not the same as owner
+    (asserts! (not (is-eq beneficiary-address sender)) ERR_INVALID_BENEFICIARY)
+    
+    ;; Ensure beneficiary is not already set or is the same
+    (asserts! (or
+        (is-none (get beneficiary vault))
+        (is-eq (some beneficiary-address) (get beneficiary vault))
+      )
+      ERR_BENEFICIARY_ALREADY_SET
+    )
     
     ;; Update vault with beneficiary
     (map-set vaults

--- a/contracts/time-locked.clar
+++ b/contracts/time-locked.clar
@@ -1,30 +1,203 @@
+;; C-Vault: Decentralized Time-Locked Asset Management
+;; A time-locked vault contract for STX tokens
+;; Author: Claude
+;; Date: February 2025
 
-;; title: time-locked
-;; version:
-;; summary:
-;; description:
+;; Error codes
+(define-constant ERR_UNAUTHORIZED (err u100))
+(define-constant ERR_NO_VAULT (err u101))
+(define-constant ERR_VAULT_LOCKED (err u102))
+(define-constant ERR_INVALID_UNLOCK_TIME (err u103))
+(define-constant ERR_ZERO_DEPOSIT (err u104))
+(define-constant ERR_INSUFFICIENT_FUNDS (err u105))
+(define-constant ERR_BENEFICIARY_ALREADY_SET (err u106))
 
-;; traits
-;;
+;; Data structures
+(define-map vaults
+  { owner: principal }
+  {
+    balance: uint,
+    unlock-height: uint,
+    beneficiary: (optional principal)
+  }
+)
 
-;; token definitions
-;;
+;; Read-only functions
 
-;; constants
-;;
+;; Get vault details for a user
+(define-read-only (get-vault (owner principal))
+  (default-to
+    {
+      balance: u0,
+      unlock-height: u0,
+      beneficiary: none
+    }
+    (map-get? vaults { owner: owner })
+  )
+)
 
-;; data vars
-;;
+;; Check if vault exists
+(define-read-only (vault-exists (owner principal))
+  (is-some (map-get? vaults { owner: owner }))
+)
 
-;; data maps
-;;
+;; Check if vault is unlocked
+(define-read-only (is-vault-unlocked (owner principal))
+  (let (
+    (vault (get-vault owner))
+    (current-height block-height)
+  )
+    (>= current-height (get unlock-height vault))
+  )
+)
 
-;; public functions
-;;
+;; Public functions
 
-;; read only functions
-;;
+;; Create or add to vault with time lock
+(define-public (deposit (amount uint) (unlock-height uint))
+  (let (
+    (sender tx-sender)
+    (current-height block-height)
+    (existing-vault (get-vault sender))
+  )
+    ;; Validate input parameters
+    (asserts! (> amount u0) ERR_ZERO_DEPOSIT)
+    (asserts! (> unlock-height current-height) ERR_INVALID_UNLOCK_TIME)
+    
+    ;; Check if vault exists
+    (if (vault-exists sender)
+      ;; If vault exists, update it
+      (let (
+        (new-balance (+ (get balance existing-vault) amount))
+        (max-unlock-height (max unlock-height (get unlock-height existing-vault)))
+      )
+        ;; Transfer STX to contract
+        (try! (stx-transfer? amount sender (as-contract tx-sender)))
+        
+        ;; Update vault
+        (map-set vaults
+          { owner: sender }
+          {
+            balance: new-balance,
+            unlock-height: max-unlock-height,
+            beneficiary: (get beneficiary existing-vault)
+          }
+        )
+        (ok new-balance)
+      )
+      ;; If vault doesn't exist, create it
+      (begin
+        ;; Transfer STX to contract
+        (try! (stx-transfer? amount sender (as-contract tx-sender)))
+        
+        ;; Create new vault
+        (map-set vaults
+          { owner: sender }
+          {
+            balance: amount,
+            unlock-height: unlock-height,
+            beneficiary: none
+          }
+        )
+        (ok amount)
+      )
+    )
+  )
+)
 
-;; private functions
-;;
+;; Withdraw from vault
+(define-public (withdraw (amount uint))
+  (let (
+    (sender tx-sender)
+    (vault (get-vault sender))
+    (vault-balance (get balance vault))
+    (unlock-height (get unlock-height vault))
+  )
+    ;; Check if vault exists
+    (asserts! (vault-exists sender) ERR_NO_VAULT)
+    
+    ;; Check if amount is valid
+    (asserts! (<= amount vault-balance) ERR_INSUFFICIENT_FUNDS)
+    
+    ;; Check if vault is unlocked
+    (asserts! (is-vault-unlocked sender) ERR_VAULT_LOCKED)
+    
+    ;; Transfer STX from contract to sender
+    (try! (as-contract (stx-transfer? amount tx-sender sender)))
+    
+    ;; Update vault balance
+    (if (is-eq amount vault-balance)
+      ;; If withdrawing entire balance, delete vault
+      (map-delete vaults { owner: sender })
+      ;; Otherwise update balance
+      (map-set vaults
+        { owner: sender }
+        {
+          balance: (- vault-balance amount),
+          unlock-height: unlock-height,
+          beneficiary: (get beneficiary vault)
+        }
+      )
+    )
+    
+    (ok true)
+  )
+)
 
+;; Set beneficiary for emergency access
+(define-public (set-beneficiary (beneficiary-address principal))
+  (let (
+    (sender tx-sender)
+    (vault (get-vault sender))
+  )
+    ;; Check if vault exists
+    (asserts! (vault-exists sender) ERR_NO_VAULT)
+    
+    ;; Update vault with beneficiary
+    (map-set vaults
+      { owner: sender }
+      {
+        balance: (get balance vault),
+        unlock-height: (get unlock-height vault),
+        beneficiary: (some beneficiary-address)
+      }
+    )
+    
+    (ok true)
+  )
+)
+
+;; Beneficiary withdrawal
+(define-public (beneficiary-withdraw (vault-owner principal))
+  (let (
+    (sender tx-sender)
+    (vault (get-vault vault-owner))
+    (vault-balance (get balance vault))
+    (vault-beneficiary (get beneficiary vault))
+  )
+    ;; Check if vault exists
+    (asserts! (vault-exists vault-owner) ERR_NO_VAULT)
+    
+    ;; Check if beneficiary is set and matches sender
+    (asserts! (and
+      (is-some vault-beneficiary)
+      (is-eq (some sender) vault-beneficiary)
+    ) ERR_UNAUTHORIZED)
+    
+    ;; Check if vault is unlocked
+    (asserts! (is-vault-unlocked vault-owner) ERR_VAULT_LOCKED)
+    
+    ;; Transfer STX from contract to beneficiary
+    (try! (as-contract (stx-transfer? vault-balance tx-sender sender)))
+    
+    ;; Delete vault after complete withdrawal
+    (map-delete vaults { owner: vault-owner })
+    
+    (ok true)
+  )
+)
+
+;; Get contract balance (for testing)
+(define-read-only (get-contract-balance)
+  (stx-get-balance (as-contract tx-sender))
+)

--- a/contracts/time-locked.clar
+++ b/contracts/time-locked.clar
@@ -1,7 +1,6 @@
 ;; C-Vault: Decentralized Time-Locked Asset Management
 ;; A time-locked vault contract for STX tokens
-;; Author: Claude
-;; Date: February 2025
+
 
 ;; Error codes
 (define-constant ERR_UNAUTHORIZED (err u100))
@@ -20,6 +19,13 @@
     unlock-height: uint,
     beneficiary: (optional principal)
   }
+)
+
+;; Helper functions
+
+;; Define our own max function since Clarity doesn't have a built-in max
+(define-private (get-max (a uint) (b uint))
+  (if (>= a b) a b)
 )
 
 ;; Read-only functions
@@ -69,7 +75,7 @@
       ;; If vault exists, update it
       (let (
         (new-balance (+ (get balance existing-vault) amount))
-        (max-unlock-height (max unlock-height (get unlock-height existing-vault)))
+        (max-unlock-height (get-max unlock-height (get unlock-height existing-vault)))
       )
         ;; Transfer STX to contract
         (try! (stx-transfer? amount sender (as-contract tx-sender)))


### PR DESCRIPTION
# Pull Request: Fix Security Vulnerability in C-Vault Beneficiary Management

## Overview
This PR addresses a critical security warning related to unchecked user input in the `set-beneficiary` function of the C-Vault contract. The warning highlights a potential vulnerability where user-supplied principal addresses were being directly used without validation.

## Changes
- Added new error code `ERR_INVALID_BENEFICIARY` (err u107)
- Implemented validation checks for beneficiary addresses:
  - Prevents vault owners from setting themselves as beneficiaries
  - Ensures beneficiaries can't be changed once set (only same address can be reconfirmed)
- Added comprehensive assertions to validate input before updating vault data

## Security Improvements
- Mitigates potential attack vectors related to beneficiary manipulation
- Improves overall contract security by enforcing proper validation
- Resolves static analysis warning from Clarity analyzer
